### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Webpack
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/4](https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/4)

To fix the problem, an explicit `permissions` block must be added to the workflow to restrict the GITHUB_TOKEN's permissions to the minimum required. For a workflow that only builds code and does not require any write access, the minimal permission set is `contents: read`. The fix can be applied at the workflow (top/root) level right after the `name:` and before `on:`, so that it applies to all jobs. No changes to existing functionality are needed, and the rest of the workflow remains unaffected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
