### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -12,6 +12,8 @@
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/3](https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/3)

To fix this issue, we should add an explicit `permissions` block to restrict the GITHUB_TOKEN's privileges. The change should be made as close to the start of the workflow YAML as possible, after the `name:` and before the `on:` key. Since the workflow doesn't do anything requiring write access to the repository, adding `permissions: contents: read` at the root level is the least privileged and adequate fix. No special imports or other changes are required in this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
