### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Grunt
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/1](https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/1)

To fix the issue, you should add a `permissions` block to the workflow to define the minimum required privileges for the GITHUB_TOKEN. Since the workflow simply checks out code and builds it, it does not require write access to contents, issues, or pull requests; thus, `contents: read` should suffice as a minimal starting point. You can add this block either at the top level (applying to all jobs), or within a specific job (here, only one job exists). The industry standard is to place it at the root level, immediately after the `name` key and before the `on` key, to ensure that all jobs that don't have a specific `permissions` block inherit it.

Required steps:
- Add the following block to the top level of `.github/workflows/npm-grunt.yml`:

  ```yaml
  permissions:
    contents: read
  ```

No additional methods, imports, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
