### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:
-      matrix:
         node-version: [18.x, 20.x, 22.x]
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/2](https://github.com/santiagourdaneta/Recetas-App-Next.js/security/code-scanning/2)

To fix the issue, add a `permissions` block to restrict the default permissions for the job as recommended. The minimal starting point is `contents: read`, which grants the necessary ability to check out the source but does not allow write access to the repository. This should be set at the job level (as there is only one job), above the `runs-on: ubuntu-latest` key, ensuring only the required permissions are granted for the build steps.

Required changes:  
- Insert a `permissions:` block in the `.github/workflows/npm-gulp.yml` file under `jobs:`, inside the `build:` job, above `runs-on:`.  
- Set `contents: read` as the value.

No external methods, imports, or new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
